### PR TITLE
tom: send stop signal when wanting to exit inside thread

### DIFF
--- a/sender
+++ b/sender
@@ -87,6 +87,7 @@ def main():
 						break
 					except:
 						log("Some exception happened. Exiting.")
+				        stop_signal.put(True)
 						break
 				filter_stopped.put(True)
 


### PR DESCRIPTION
forwarder on LeMonitor died today:

2016-03-16 05:54:10.866407500 Socket error: [Errno 110] Connection timed out
2016-03-16 05:54:10.882325500 Some exception happened. Exiting.

It doesn't exit and gets stuck there. Will this commit help?

I think the disconnect may have been due to firewall change fuckup.